### PR TITLE
Synchronise les prérequis Node.js du cours TypeScript 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ cours TypeScript de Dyma.
 - Node.js 20.19+, 22.12+ ou 24 LTS
 - npm
 
+La contrainte correspondante est déclarée dans `package.json` afin qu'une
+version de Node.js incompatible soit signalée dès l'installation.
+
 ## Installation
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "devDependencies": {
         "typescript": "7.0.2",
         "vite": "8.1.5"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "Projet Vite 8.1 et TypeScript 7 du cours Dyma",
   "type": "module",
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  },
   "scripts": {
     "dev": "vite",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Modifications

- déclare dans `package.json` la version de Node.js exigée par Vite 8.1 ;
- synchronise `package-lock.json` ;
- explique ce contrôle dans le README.

## Pourquoi

La leçon écrite et le README indiquent Node.js 20.19+, 22.12+ ou 24 LTS, mais le manifeste npm ne contrôlait pas cette contrainte lors de l’installation.

## Validation

- comparaison de `tsconfig.json`, des scripts npm, de `index.html` et de `src/main.ts` avec les blocs finaux de C1L7 ;
- `npm ci` ;
- `npm run typecheck` ;
- `npm run build` ;
- vérification des dernières versions npm : TypeScript 7.0.2 et Vite 8.1.5.